### PR TITLE
Allow builds on aarch64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,8 +85,8 @@
             '';
 
             postInstall = o.postInstall + ''
-              cp ${self.packages.${builtins.currentSystem}.emacs-vterm}/vterm.el $out/share/emacs/site-lisp/vterm.el
-              cp ${self.packages.${builtins.currentSystem}.emacs-vterm}/vterm-module.so $out/share/emacs/site-lisp/vterm-module.so
+              cp ${final.emacs-vterm}/vterm.el $out/share/emacs/site-lisp/vterm.el
+              cp ${final.emacs-vterm}/vterm-module.so $out/share/emacs/site-lisp/vterm-module.so
             '';
 
             CFLAGS = "-DMAC_OS_X_VERSION_MAX_ALLOWED=110203 -g -O2";


### PR DESCRIPTION
Hi, thanks this repo! I've added support for aarch64-darwin to the flake, modeled after the examples in templates#hello-c and elsewhere. It builds and runs successfully on my new MacBook Pro 2021 and I think it might be useful to add least let people build it themselves, even if CI builds for M1 aren't available yet. What do you think?