### PR TITLE
ci: bump install-nix-action to v16

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,9 +30,8 @@ jobs:
         fetch-depth: 0
  
     - name: Install Nix
-      uses: cachix/install-nix-action@v13
+      uses: cachix/install-nix-action@v16
       with:
-        install_url: https://github.com/numtide/nix-flakes-installer/releases/download/nix-2.4pre20210823_af94b54/install
         extra_nix_config: |
           experimental-features = nix-command flakes
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I noticed the automated builds have been failing for quite a while now, about 23 days.

https://github.com/cmacrae/emacs/actions/runs/1547228221

This run appears to be the first automated run that failed, and each automated run since has failed. Looks like it's getting stuck on some issue during the `install-nix-action` step. In my fork, I've seen similar errors, and I believe they went away when I updated to the latest version of the `install-nix-action`. 

Here's the full error from the latest run:

```
/nix:
Error: unable to perform operation.  (-400)
	Error: unknown indexing state.
child_process.js:642
    throw err;
    ^

Error: Command failed: /Users/runner/work/_actions/cachix/install-nix-action/v13/lib/install-nix.sh
    at checkExecSyncError (child_process.js:621:11)
    at Object.execFileSync (child_process.js:639:15)
    at Object.<anonymous> (/Users/runner/work/_actions/cachix/install-nix-action/v13/lib/main.js:4:17)
    at Module._compile (internal/modules/cjs/loader.js:959:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:995:10)
    at Module.load (internal/modules/cjs/loader.js:815:32)
    at Function.Module._load (internal/modules/cjs/loader.js:727:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1047:10)
    at internal/main/run_main_module.js:17:11 {
  status: 1,
  signal: null,
  output: [ null, null, null ],
  pid: 848,
  stdout: null,
  stderr: null
}
```