### PR TITLE
Adds support for x86_64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Nightly custom Emacs builds for macOS";
+  description = "Nightly custom Emacs builds for macOS and Linux";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
@@ -17,7 +17,7 @@
 
   outputs = { self, nixpkgs, emacs-src, emacs-vterm-src }:
     let
-      supportedSystems = [ "x86_64-darwin" "aarch64-darwin" ];
+      supportedSystems = [ "x86_64-darwin" "aarch64-darwin" "x86_64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       nixpkgsFor = forAllSystems (system: import nixpkgs {
         inherit system;
@@ -72,7 +72,7 @@
             version = "29.0.50";
             src = emacs-src;
 
-            buildInputs = o.buildInputs ++ [ prev.darwin.apple_sdk.frameworks.WebKit ];
+              buildInputs = o.buildInputs ++ (final.lib.optionals final.stdenv.isDarwin [ prev.darwin.apple_sdk.frameworks.WebKit ]);
 
             patches = [
               ./patches/fix-window-role.patch


### PR DESCRIPTION
This PR adds support to build for x86_64-linux in addition to existing Darwin system support. It builds cleanly and runs on a minimal NixOS 22.05 VM.