### PR TITLE
Update github action dependencies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,20 +24,20 @@ jobs:
     runs-on: macos-latest
     steps:
 
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v3.5.3
       with:
         # Nix Flakes doesn't work on shallow clones
         fetch-depth: 0
  
     - name: Install Nix
-      uses: cachix/install-nix-action@v16
+      uses: cachix/install-nix-action@v22
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes
           access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up binary cache
-      uses: cachix/cachix-action@v10
+      uses: cachix/cachix-action@v12
       with:
         name: emacs
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -71,7 +71,7 @@ jobs:
         echo -e "\n\e[4mDerivation\e[0m\n"
         cat ./emacs.drv
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3.3.1
       id: cache-drv
       with:
         path: ./emacs.drv
@@ -82,7 +82,7 @@ jobs:
 
     - run: rm -f emacs.drv
 
-    - uses: stefanzweifel/git-auto-commit-action@v4
+    - uses: stefanzweifel/git-auto-commit-action@v4.16.0
       if: ${{ success() }}
       with:
         commit_message: "automation: Emacs ${{ steps.version.outputs.ver }} -> ${{ steps.version.outputs.rev }}"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 This repository provides nightly automated builds of Emacs from HEAD for macOS Nix environments with the following additions:
 - Native Compilation ([gccemacs](https://www.emacswiki.org/emacs/GccEmacs))
-- [X Widgets](https://www.emacswiki.org/emacs/EmacsXWidgets) (Webkit) support
 - [libvterm](https://github.com/akermu/emacs-libvterm)
 - Patched window role to work nicely with [yabai](https://github.com/koekeishiya/yabai)
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "emacs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1685464105,
-        "narHash": "sha256-Y0uuemxviXxi4WQEn2fb3derGaDLJxDH10qGXkpmKDQ=",
+        "lastModified": 1692698020,
+        "narHash": "sha256-TOWpAiSknpTLctuMD2KLVjw5xSuOrcBzjUGkOjJMTWw=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "ecc1d990d9e9d006838ca514213ea5e46a459363",
+        "rev": "6ab90effbe5dbda01a934c3d8eaccf4aa835b60d",
         "type": "github"
       },
       "original": {
@@ -34,11 +34,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1685399834,
-        "narHash": "sha256-Lt7//5snriXSdJo5hlVcDkpERL1piiih0UXIz1RUcC4=",
+        "lastModified": 1692557222,
+        "narHash": "sha256-TCOtZaioLf/jTEgfa+nyg0Nwq5Uc610Z+OFV75yUgGw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "58c85835512b0db938600b6fe13cc3e3dc4b364e",
+        "rev": "0b07d4957ee1bd7fd3bdfd12db5f361bd70175a6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
           '';
         };
 
-        emacs = (prev.emacs.override { srcRepo = true; nativeComp = true; withXwidgets = true; withGTK3 = true; }).overrideAttrs (
+        emacs = (prev.emacs.override { srcRepo = true; withNativeCompilation = true; withXwidgets = false; withGTK3 = true; }).overrideAttrs (
           o: rec {
             version = "30.0.50";
             src = emacs-src;


### PR DESCRIPTION
There hasn't been any build in a while, and one of the problems is https://github.com/cachix/install-nix-action/issues/183. I believe bumping `cachix/install-nix-actions` to v22 should fix this. Additionally I've bumped the other ones to the latest, which should hopefully remove to NodeJS 12 warnings etc.